### PR TITLE
Make *PRNG* be thread-local

### DIFF
--- a/ironclad.asd
+++ b/ironclad.asd
@@ -14,7 +14,7 @@
   :description "A cryptographic toolkit written in pure Common Lisp"
   :license "BSD 3-Clause"
   :default-component-class ironclad-source-file
-  :depends-on (#+sbcl "sb-rotate-byte" #+sbcl "sb-posix" "nibbles")
+  :depends-on (#+sbcl "sb-rotate-byte" #+sbcl "sb-posix" "nibbles" "bordeaux-threads")
   :in-order-to ((test-op (test-op "ironclad/tests")))
   :components ((:static-file "LICENSE")
                (:static-file "NEWS")

--- a/src/prng/os-prng.lisp
+++ b/src/prng/os-prng.lisp
@@ -37,3 +37,4 @@
   (make-instance 'os-prng))
 
 (setf *prng* (make-prng :os))
+#+thread-support(pushnew '(*prng* . (make-prng :os)) bt:*default-special-bindings* :test #'equal)


### PR DESCRIPTION
Addresses #9 & #13.

It appears that BORDEAUX-THREADS supports all Lisps which IRONCLAD is
tested under, and so depending on it shouldn't hurt.

Notably, this does _not_ use locking.