### PR TITLE
Do not close in finalizer on sbcl

### DIFF
--- a/src/prng/os-prng.lisp
+++ b/src/prng/os-prng.lisp
@@ -58,7 +58,8 @@
                         #+ccl :sharing #+ccl :external
                         :element-type '(unsigned-byte 8))))
       (setf (slot-value prng 'source) source)
-      (trivial-garbage:finalize prng (lambda () (close source))))
+      ;; sbcl already does this
+      #-sbcl (trivial-garbage:finalize prng (lambda () (close source))))
     prng))
 
 (setf *prng* (make-prng :os))


### PR DESCRIPTION
SBCL itself is already doing the exact same thing, see:

https://github.com/sbcl/sbcl/blob/master/contrib/sb-simple-streams/internal.lisp#L656

which calls: https://github.com/sbcl/sbcl/blob/master/src/code/fd-stream.lisp#L2285-L2292

In my case, I ended up going down that rabbit hole because the FD reported by `source` (i.e. the underlying fd-stream), aka `(sb-sys:fd-stream-fd (slot-value ironclad:*prng* 'ironclad::source))`, had a different file descriptor in `/proc/$pid/fd/`. The behavior I was observing was a stuck read -- most likely because the real file descriptor stored in fd-stream was a socket.

I assume it is related to double-closing, one way or another.