### PR TITLE
fixes/workarounds for Clozure CL for ARM32 test failures

### DIFF
--- a/src/ciphers/rc2.lisp
+++ b/src/ciphers/rc2.lisp
@@ -91,8 +91,8 @@
                              `(progn
                                (setf ,x0 (ldb (byte 16 0)
                                           (+ ,x0
-                                             (aref round-keys (+ (* 4 ,index) ,i))
                                              (logand ,x1 ,x2)
+                                             (aref round-keys (+ (* 4 ,index) ,i))
                                              (logandc1 ,x1 ,x3))))
                                (setf ,x0 (rol16 ,x0 ,(case i
                                                            (0 1)

--- a/src/digests/adler32.lisp
+++ b/src/digests/adler32.lisp
@@ -20,7 +20,7 @@
   state)
 
 (defmethod copy-digest ((state adler32) &optional copy)
-  (declare (type (or null adler32) copy))
+  (check-type copy (or null adler32))
   (cond
     (copy
      (setf (adler32-s1 copy) (adler32-s1 state)

--- a/src/digests/blake2.lisp
+++ b/src/digests/blake2.lisp
@@ -174,7 +174,7 @@
   state)
 
 (defmethod copy-digest ((state blake2) &optional copy)
-  (declare (type (or null blake2) copy))
+  (check-type copy (or null blake2))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/blake2s.lisp
+++ b/src/digests/blake2s.lisp
@@ -187,7 +187,7 @@
   state)
 
 (defmethod copy-digest ((state blake2s) &optional copy)
-  (declare (type (or null blake2s) copy))
+  (check-type copy (or null blake2s))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/crc24.lisp
+++ b/src/digests/crc24.lisp
@@ -62,7 +62,7 @@
   state)
 
 (defmethod copy-digest ((state crc24) &optional copy)
-  (declare (type (or null crc24) copy))
+  (check-type copy (or null crc24))
   (cond
     (copy
      (setf (crc24-crc copy) (crc24-crc state))

--- a/src/digests/crc32.lisp
+++ b/src/digests/crc32.lisp
@@ -62,7 +62,7 @@
   state)
 
 (defmethod copy-digest ((state crc32) &optional copy)
-  (declare (type (or null crc32) copy))
+  (check-type copy (or null crc32))
   (cond
     (copy
      (setf (crc32-crc copy) (crc32-crc state))

--- a/src/digests/groestl.lisp
+++ b/src/digests/groestl.lisp
@@ -1056,10 +1056,7 @@
          (ftype (function ((integer 0 2048)) (unsigned-byte 64)) groestl-table))
 (defun groestl-table (i)
   (declare (type (integer 0 2048) i))
-  (let ((constants (load-time-value +groestl-table+ t)))
-    (declare (type (simple-array (unsigned-byte 64) (2048)) constants))
-    (aref constants i)))
-
+  (aref +groestl-table+ i))
 
 ;;;
 ;;; Rounds
@@ -1367,7 +1364,7 @@
   state)
 
 (defmethod copy-digest ((state groestl) &optional copy)
-  (declare (type (or null groestl) copy))
+  (check-type copy (or null groestl))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/jh.lisp
+++ b/src/digests/jh.lisp
@@ -410,7 +410,7 @@
   state)
 
 (defmethod copy-digest ((state jh) &optional copy)
-  (declare (type (or null jh) copy))
+  (check-type copy (or null jh))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/kupyna.lisp
+++ b/src/digests/kupyna.lisp
@@ -271,6 +271,7 @@
   state)
 
 (defmethod copy-digest ((state kupyna) &optional copy)
+  (check-type copy (or null kupyna))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/md2.lisp
+++ b/src/digests/md2.lisp
@@ -93,7 +93,7 @@
   state)
 
 (defmethod copy-digest ((state md2) &optional copy)
-  (declare (type (or null md2) copy))
+  (check-type copy (or null md2))
   (cond
     (copy
      (replace (md2-regs copy) (md2-regs state))

--- a/src/digests/md4.lisp
+++ b/src/digests/md4.lisp
@@ -78,7 +78,7 @@
   state)
 
 (defmethod copy-digest ((state md4) &optional copy)
-  (declare (type (or null md4) copy))
+  (check-type copy (or null md4))
   (cond
     (copy
      (replace (md4-regs copy) (md4-regs state))

--- a/src/digests/md5.lisp
+++ b/src/digests/md5.lisp
@@ -161,7 +161,7 @@ accordingly."
   state)
 
 (defmethod copy-digest ((state md5) &optional copy)
-  (declare (type (or null md5) copy))
+  (check-type copy (or null md5))
   (cond
    (copy
     (replace (md5-regs copy) (md5-regs state))

--- a/src/digests/ripemd-128.lisp
+++ b/src/digests/ripemd-128.lisp
@@ -143,7 +143,7 @@
   state)
 
 (defmethod copy-digest ((state ripemd-128) &optional copy)
-  (declare (type (or null ripemd-128) copy))
+  (check-type copy (or null ripemd-128))
   (cond
     (copy
      (replace (ripemd-128-regs copy) (ripemd-128-regs state))

--- a/src/digests/ripemd-160.lisp
+++ b/src/digests/ripemd-160.lisp
@@ -167,7 +167,7 @@
   state)
 
 (defmethod copy-digest ((state ripemd-160) &optional copy)
-  (declare (type (or null ripemd-160) copy))
+  (check-type copy (or null ripemd-160))
   (cond
     (copy
      (replace (ripemd-160-regs copy) (ripemd-160-regs state))

--- a/src/digests/sha1.lisp
+++ b/src/digests/sha1.lisp
@@ -153,7 +153,7 @@ available."
   state)
 
 (defmethod copy-digest ((state sha1) &optional copy)
-  (declare (type (or null sha1) copy))
+  (check-type copy (or null sha1))
   (cond
     (copy
      (replace (sha1-regs copy) (sha1-regs state))

--- a/src/digests/sha256.lisp
+++ b/src/digests/sha256.lisp
@@ -140,7 +140,7 @@
   state)
 
 (defmethod copy-digest ((state sha256) &optional copy)
-  (declare (type (or null sha256) copy))
+  (check-type copy (or null sha256))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/sha3.lisp
+++ b/src/digests/sha3.lisp
@@ -362,7 +362,7 @@ the content on normal form exit."
   state)
 
 (defmethod copy-digest ((state sha3) &optional copy)
-  (declare (type (or null sha3) copy))
+  (check-type copy (or null sha3))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/sha512.lisp
+++ b/src/digests/sha512.lisp
@@ -152,7 +152,7 @@
   state)
 
 (defmethod copy-digest ((state sha512) &optional copy)
-  (declare (type (or null sha512) copy))
+  (check-type copy (or null sha512))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/skein.lisp
+++ b/src/digests/skein.lisp
@@ -478,7 +478,7 @@
   (%reinitialize-skein256 state 224))
 
 (defmethod copy-digest ((state skein256) &optional copy)
-  (declare (type (or null skein256) copy))
+  (check-type copy (or null skein256))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/sm3.lisp
+++ b/src/digests/sm3.lisp
@@ -250,7 +250,7 @@
   state)
 
 (defmethod copy-digest ((state sm3) &optional copy)
-  (declare (type (or null sm3) copy))
+  (check-type copy (or null sm3))
   (let ((copy (if copy copy (%make-sm3-digest))))
     (declare (type sm3 copy))
     (replace (sm3-state copy) (sm3-state state))

--- a/src/digests/streebog.lisp
+++ b/src/digests/streebog.lisp
@@ -1223,7 +1223,7 @@
   state)
 
 (defmethod copy-digest ((state streebog) &optional copy)
-  (declare (type (or null streebog) copy))
+  (check-type copy (or null streebog))
   (let ((copy (if copy
                   copy
                   (etypecase state

--- a/src/digests/tiger.lisp
+++ b/src/digests/tiger.lisp
@@ -831,7 +831,7 @@
   state)
 
 (defmethod copy-digest ((state tiger) &optional copy)
-  (declare (type (or null tiger) copy))
+  (check-type copy (or null tiger))
   (cond
     (copy
      (replace (tiger-regs copy) (tiger-regs state))

--- a/src/digests/tree-hash.lisp
+++ b/src/digests/tree-hash.lisp
@@ -43,7 +43,7 @@
   state)
 
 (defmethod copy-digest ((state tree-hash) &optional copy)
-  (declare (type (or null tree-hash) copy))
+  (check-type copy (or null tree-hash))
   (cond
     (copy
      (copy-digest (tree-hash-state state) (tree-hash-state copy))

--- a/src/digests/whirlpool.lisp
+++ b/src/digests/whirlpool.lisp
@@ -246,7 +246,7 @@ word block of input, and updates the working state in the regs."
   state)
 
 (defmethod copy-digest ((state whirlpool) &optional copy)
-  (declare (type (or null whirlpool) copy))
+  (check-type copy (or whirlpool null))
   (cond
     (copy
      (replace (whirlpool-regs copy) (whirlpool-regs state))


### PR DESCRIPTION
The modifications to rc2.lisp to rearrange two lines of code and the change to groestl.lisp to use the +groestl-table+ directly are workarounds for (seeming) compiler bugs in Clozure CL for ARM32.  They should be benign on all other platforms (I think)

The modifications to the copy-digest methods in all the digest classes I believe are more globally appropriate; the use of type declare statements do not guarantee the emission of a runtime type check in code even though they typically do.  There was one class (tree-hash) where Clozure CL for ARM32 seemingly missed the type check and caused a crash in the copy-digest.error test.  An explicit (check-type ...) seems more definite.  