### PR TITLE
Include the prime factors for RSA private keys

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -86,7 +86,7 @@
    ;; public-key slot readers
    #:dsa-key-p #:dsa-key-q #:dsa-key-g #:dsa-key-y #:dsa-key-x
    #:elgamal-key-p #:elgamal-key-g #:elgamal-key-y #:elgamal-key-x
-   #:rsa-key-modulus #:rsa-key-exponent
+   #:rsa-key-modulus #:rsa-key-exponent #:rsa-key-prime-p #:rsa-key-prime-q
    #:ed25519-key-x #:ed25519-key-y
    #:ed448-key-x #:ed448-key-y
    #:curve25519-key-x #:curve25519-key-y

--- a/src/public-key/rsa.lisp
+++ b/src/public-key/rsa.lisp
@@ -3,7 +3,6 @@
 
 (in-package :crypto)
 
-
 ;;; class definitions
 
 (defclass rsa-key ()
@@ -13,9 +12,10 @@
   ((e :initarg :e :reader rsa-key-exponent :type integer)))
 
 (defclass rsa-private-key (rsa-key)
-  ((d :initarg :d :reader rsa-key-exponent :type integer)))
+  ((d :initarg :d :reader rsa-key-exponent :type integer)
+   (p :initarg :p :reader rsa-key-prime-p :type integer)
+   (q :initarg :q :reader rsa-key-prime-q :type integer)))
 
-
 ;;; function definitions
 
 (defmethod make-public-key ((kind (eql :rsa))
@@ -37,7 +37,7 @@
         :n (rsa-key-modulus public-key)))
 
 (defmethod make-private-key ((kind (eql :rsa))
-                             &key d n &allow-other-keys)
+                             &key d n p q &allow-other-keys)
   (unless d
     (error 'missing-key-parameter
            :kind 'rsa
@@ -48,11 +48,13 @@
            :kind 'rsa
            :parameter 'n
            :description "modulus"))
-  (make-instance 'rsa-private-key :d d :n n))
+  (make-instance 'rsa-private-key :d d :n n :p p :q q))
 
 (defmethod destructure-private-key ((private-key rsa-private-key))
   (list :d (rsa-key-exponent private-key)
-        :n (rsa-key-modulus private-key)))
+        :n (rsa-key-modulus private-key)
+        :p (rsa-key-prime-p private-key)
+        :q (rsa-key-prime-q private-key)))
 
 (defmethod generate-key-pair ((kind (eql :rsa)) &key num-bits &allow-other-keys)
   (unless num-bits
@@ -72,7 +74,7 @@
                       until (= 1 (gcd e phi))
                       finally (return e)))
              (d (modular-inverse-with-blinding e phi)))
-        (values (make-private-key :rsa :d d :n n)
+        (values (make-private-key :rsa :d d :n n :p p :q q)
                 (make-public-key :rsa :e e :n n))))))
 
 (defun rsa-core (msg exponent modulus)


### PR DESCRIPTION
I'm intending to use `ironclad` for generating private/public key pairs, which will then be encoded as OpenSSH private and public keys.

The RSA primes `p` and `q` are also part of the binary blob for OpenSSH private keys, so in order to properly encode a private key in OpenSSH format I need to have these as part of the `RSA-PRIVATE-KEY` class.

This MR adds `p` and `q` primes to `RSA-PRIVATE-KEY` class and also exports their readers -- `RSA-KEY-PRIME-P` and `RSA-KEY-PRIME-Q` respectively.
