### PR TITLE
Add new generic function for destructuring EC points

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -91,6 +91,24 @@
    #:secp384r1-public-key #:secp384r1-private-key
    #:secp521r1-public-key #:secp521r1-private-key
 
+   ;; EC operations
+   #:ec-point-on-curve-p #:ec-point-equal
+   #:ec-double #:ec-add #:ec-scalar-mult
+   #:ec-scalar-inv #:ec-encode-scalar
+   #:ec-decode-scalar #:ec-encode-point
+   #:ec-decode-point #:ec-destructure-point
+
+   ;; EC point classes and readers
+   #:curve25519-point #:curve25519-point-x #:curve25519-point-z
+   #:curve448-point #:curve448-point-x #:curve448-point-z
+   #:ed25519-point #:ed25519-point-x #:ed25519-point-y
+   #:ed25519-point-z #:ed25519-point-w
+   #:ed448-point #:ed448-point-x #:ed448-point-y #:ed448-point-z
+   #:secp256k1-point #:secp256k1-point-x #:secp256k1-point-y #:secp256k1-point-z
+   #:secp256r1-point #:secp256r1-point-x #:secp256r1-point-y #:secp256r1-point-z
+   #:secp384r1-point #:secp384r1-point-x #:secp384r1-point-y #:secp384r1-point-z
+   #:secp521r1-point #:secp521r1-point-x #:secp521r1-point-y #:secp521r1-point-z
+
    ;; public-key slot readers
    #:dsa-key-p #:dsa-key-q #:dsa-key-g #:dsa-key-y #:dsa-key-x
    #:elgamal-key-p #:elgamal-key-g #:elgamal-key-y #:elgamal-key-x

--- a/src/public-key/curve25519.lisp
+++ b/src/public-key/curve25519.lisp
@@ -17,8 +17,8 @@
   (defclass curve25519-point ()
     ;; Internally, we represent a point (x, y) using only the projective
     ;; coordinate (X, Z) for x, with x = X / Z.
-    ((x :initarg :x :type integer)
-     (z :initarg :z :type integer)))
+    ((x :initarg :x :reader curve25519-point-x :type integer)
+     (z :initarg :z :reader curve25519-point-z :type integer)))
   (defmethod make-load-form ((p curve25519-point) &optional env)
     (declare (ignore env))
     (make-load-form-saving-slots p)))
@@ -106,6 +106,10 @@
   (let ((x (ldb (byte (1- +curve25519-bits+) 0)
                 (octets-to-integer octets :big-endian nil))))
     (make-instance 'curve25519-point :x x :z 1)))
+
+(defmethod ec-destructure-point ((point curve25519-point))
+  (list :x (curve25519-point-x point)
+        :z (curve25519-point-z point)))
 
 (defun curve25519-public-key (sk)
   "Compute the public key associated to the private key SK."

--- a/src/public-key/curve448.lisp
+++ b/src/public-key/curve448.lisp
@@ -17,8 +17,8 @@
   (defclass curve448-point ()
     ;; Internally, we represent a point (x, y) using only the projective
     ;; coordinate (X, Z) for x, with x = X / Z.
-    ((x :initarg :x :type integer)
-     (z :initarg :z :type integer)))
+    ((x :initarg :x :reader curve448-point-x :type integer)
+     (z :initarg :z :reader curve448-point-z :type integer)))
   (defmethod make-load-form ((p curve448-point) &optional env)
     (declare (ignore env))
     (make-load-form-saving-slots p)))
@@ -106,6 +106,10 @@
   (let ((x (ldb (byte +curve448-bits+ 0)
                 (octets-to-integer octets :big-endian nil))))
     (make-instance 'curve448-point :x x :z 1)))
+
+(defmethod ec-destructure-point ((point curve448-point))
+  (list :x (curve448-point-x point)
+        :z (curve448-point-z point)))
 
 (defun curve448-public-key (sk)
   "Compute the public key associated to the private key SK."

--- a/src/public-key/ed25519.lisp
+++ b/src/public-key/ed25519.lisp
@@ -17,10 +17,10 @@
   (defclass ed25519-point ()
     ;; Internally, a point (x, y) is represented in extended homogeneous
     ;; coordinates (X, Y, Z, W), with x = X / Z, y = Y / Z and x * y = W / Z.
-    ((x :initarg :x :type integer)
-     (y :initarg :y :type integer)
-     (z :initarg :z :type integer)
-     (w :initarg :w :type integer)))
+    ((x :initarg :x :reader ed25519-point-x :type integer)
+     (y :initarg :y :reader ed25519-point-y :type integer)
+     (z :initarg :z :reader ed25519-point-z :type integer)
+     (w :initarg :w :reader ed25519-point-w :type integer)))
   (defmethod make-load-form ((p ed25519-point) &optional env)
     (declare (ignore env))
     (make-load-form-saving-slots p)))
@@ -179,6 +179,12 @@
         (if (ec-point-on-curve-p p)
             p
             (error 'invalid-curve-point :kind 'ed25519))))))
+
+(defmethod ec-destructure-point ((point ed25519-point))
+  (list :x (ed25519-point-x point)
+        :y (ed25519-point-y point)
+        :z (ed25519-point-z point)
+        :w (ed25519-point-w point)))
 
 (defun ed25519-hash (&rest messages)
   (declare (optimize (speed 3) (safety 0) (space 0) (debug 0)))

--- a/src/public-key/ed448.lisp
+++ b/src/public-key/ed448.lisp
@@ -17,9 +17,9 @@
   (defclass ed448-point ()
     ;; Internally, a point (x, y) is represented using the projective
     ;; coordinates (X, Y, Z), with x = X / Z and y = Y / Z.
-    ((x :initarg :x :type integer)
-     (y :initarg :y :type integer)
-     (z :initarg :z :type integer)))
+    ((x :initarg :x :reader ed448-point-x :type integer)
+     (y :initarg :y :reader ed448-point-y :type integer)
+     (z :initarg :z :reader ed448-point-z :type integer)))
   (defmethod make-load-form ((p ed448-point) &optional env)
     (declare (ignore env))
     (make-load-form-saving-slots p)))
@@ -183,6 +183,11 @@
         (if (ec-point-on-curve-p p)
             p
             (error 'invalid-curve-point :kind 'ed448))))))
+
+(defmethod ec-destructure-point ((point ed448-point))
+  (list :x (ed448-point-x point)
+        :y (ed448-point-y point)
+        :z (ed448-point-z point)))
 
 (defun ed448-hash (&rest messages)
   (declare (optimize (speed 3) (safety 0) (space 0) (debug 0)))

--- a/src/public-key/elliptic-curve.lisp
+++ b/src/public-key/elliptic-curve.lisp
@@ -32,3 +32,6 @@
 
 (defgeneric ec-decode-point (kind octets)
   (:documentation "Return the point represented by the OCTETS."))
+
+(defgeneric ec-destructure-point (p)
+  (:documentation "Return a plist containing the elements of the point P"))

--- a/src/public-key/secp256k1.lisp
+++ b/src/public-key/secp256k1.lisp
@@ -18,9 +18,9 @@
   (defclass secp256k1-point ()
     ;; Internally, a point (x, y) is represented using the Jacobian projective
     ;; coordinates (X, Y, Z), with x = X / Z^2 and y = Y / Z^3.
-    ((x :initarg :x :type integer)
-     (y :initarg :y :type integer)
-     (z :initarg :z :type integer)))
+    ((x :initarg :x :reader secp256k1-point-x :type integer)
+     (y :initarg :y :reader secp256k1-point-y :type integer)
+     (z :initarg :z :reader secp256k1-point-z :type integer)))
   (defmethod make-load-form ((p secp256k1-point) &optional env)
     (declare (ignore env))
     (make-load-form-saving-slots p)))
@@ -190,6 +190,11 @@
          (error 'invalid-curve-point :kind 'secp256k1)))
     (t
      (error 'invalid-curve-point :kind 'secp256k1))))
+
+(defmethod ec-destructure-point ((point secp256k1-point))
+  (list :x (secp256k1-point-x point)
+        :y (secp256k1-point-y point)
+        :z (secp256k1-point-z point)))
 
 (defun secp256k1-public-key (sk)
   (let ((a (ec-decode-scalar :secp256k1 sk)))

--- a/src/public-key/secp256r1.lisp
+++ b/src/public-key/secp256r1.lisp
@@ -18,9 +18,9 @@
   (defclass secp256r1-point ()
     ;; Internally, a point (x, y) is represented using the Jacobian projective
     ;; coordinates (X, Y, Z), with x = X / Z^2 and y = Y / Z^3.
-    ((x :initarg :x :type integer)
-     (y :initarg :y :type integer)
-     (z :initarg :z :type integer)))
+    ((x :initarg :x :reader secp256r1-point-x :type integer)
+     (y :initarg :y :reader secp256r1-point-y :type integer)
+     (z :initarg :z :reader secp256r1-point-z :type integer)))
   (defmethod make-load-form ((p secp256r1-point) &optional env)
     (declare (ignore env))
     (make-load-form-saving-slots p)))
@@ -193,6 +193,11 @@
          (error 'invalid-curve-point :kind 'secp256r1)))
     (t
      (error 'invalid-curve-point :kind 'secp256r1))))
+
+(defmethod ec-destructure-point ((point secp256r1-point))
+  (list :x (secp256r1-point-x point)
+        :y (secp256r1-point-y point)
+        :z (secp256r1-point-z point)))
 
 (defun secp256r1-public-key (sk)
   (let ((a (ec-decode-scalar :secp256r1 sk)))

--- a/src/public-key/secp384r1.lisp
+++ b/src/public-key/secp384r1.lisp
@@ -18,9 +18,9 @@
   (defclass secp384r1-point ()
     ;; Internally, a point (x, y) is represented using the Jacobian projective
     ;; coordinates (X, Y, Z), with x = X / Z^2 and y = Y / Z^3.
-    ((x :initarg :x :type integer)
-     (y :initarg :y :type integer)
-     (z :initarg :z :type integer)))
+    ((x :initarg :x :reader secp384r1-point-x :type integer)
+     (y :initarg :y :reader secp384r1-point-y :type integer)
+     (z :initarg :z :reader secp384r1-point-z :type integer)))
   (defmethod make-load-form ((p secp384r1-point) &optional env)
     (declare (ignore env))
     (make-load-form-saving-slots p)))
@@ -193,6 +193,11 @@
          (error 'invalid-curve-point :kind 'secp384r1)))
     (t
      (error 'invalid-curve-point :kind 'secp384r1))))
+
+(defmethod ec-destructure-point ((point secp384r1-point))
+  (list :x (secp384r1-point-x point)
+        :y (secp384r1-point-y point)
+        :z (secp384r1-point-z point)))
 
 (defun secp384r1-public-key (sk)
   (let ((a (ec-decode-scalar :secp384r1 sk)))

--- a/src/public-key/secp521r1.lisp
+++ b/src/public-key/secp521r1.lisp
@@ -18,9 +18,9 @@
   (defclass secp521r1-point ()
     ;; Internally, a point (x, y) is represented using the Jacobian projective
     ;; coordinates (X, Y, Z), with x = X / Z^2 and y = Y / Z^3.
-    ((x :initarg :x :type integer)
-     (y :initarg :y :type integer)
-     (z :initarg :z :type integer)))
+    ((x :initarg :x :reader secp521r1-point-x :type integer)
+     (y :initarg :y :reader secp521r1-point-y :type integer)
+     (z :initarg :z :reader secp521r1-point-z  :type integer)))
   (defmethod make-load-form ((p secp521r1-point) &optional env)
     (declare (ignore env))
     (make-load-form-saving-slots p)))
@@ -193,6 +193,11 @@
          (error 'invalid-curve-point :kind 'secp521r1)))
     (t
      (error 'invalid-curve-point :kind 'secp521r1))))
+
+(defmethod ec-destructure-point ((point secp521r1-point))
+  (list :x (secp521r1-point-x point)
+        :y (secp521r1-point-y point)
+        :z (secp521r1-point-z point)))
 
 (defun secp521r1-public-key (sk)
   (let ((a (ec-decode-scalar :secp521r1 sk)))


### PR DESCRIPTION
This PR adds a new generic function - `EC-DESTRUCTURE-POINT` and provides implementation for the existing EC point classes.

Also, it exports the various EC point operations and adds slot readers.