### PR TITLE
Improve performance in LispWorks.

### DIFF
--- a/src/ciphers/blowfish.lisp
+++ b/src/ciphers/blowfish.lisp
@@ -244,6 +244,8 @@
     (store-words ciphertext ciphertext-start right left)))
 
 (defun initialize-blowfish-vectors (key p-array s-boxes)
+  #+lispworks
+  (declare (optimize (debug 0) (float 0) (space 0) (safety 0) (speed 3)))
   (declare (type (simple-array (unsigned-byte 8) (*)) key))
   (declare (type blowfish-p-array p-array))
   (declare (type blowfish-s-boxes s-boxes))

--- a/src/common.lisp
+++ b/src/common.lisp
@@ -404,7 +404,8 @@ uint64_t r = (n << 56)
          (ftype (function ((unsigned-byte 32) (unsigned-byte 32)) (unsigned-byte 32)) mod32+))
 
 (defun mod32+ (a b)
-  (declare (type (unsigned-byte 32) a b))
+  (declare (type (unsigned-byte 32) a b)
+           #+lispworks(optimize (debug 0) (space 0) (safety 0) (float 0) (speed 3)))
   #+(and ccl x86-64 ironclad-assembly)
   (%mod32+ a b)
 


### PR DESCRIPTION
bcrypt is too slow in LispWorks:
```lisp
(bcrypt:make-password "password"  :cost 10 :identifier "2b")
```
Once optimizations are enabled, the performance becomes acceptable.